### PR TITLE
Release for v0.0.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,10 @@ jobs:
       - { uses: actions/download-artifact@v4, with: { name: darwin-x64,    path: release/ } }
       - { uses: actions/download-artifact@v4, with: { name: darwin-arm64,  path: release/ } }
 
+      - name: DEBUG
+        run: |
+          ls -la release/
+
       - name: Release
         uses: fnkr/github-action-ghr@v1
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [v0.0.2](https://github.com/yumafuu/ghq-fzf/compare/v0.0.1...v0.0.2) - 2024-12-16
+
 ## [v0.0.1](https://github.com/yumafuu/ghq-fzf/commits/v0.0.1) - 2024-12-12
 
 ## [v0.0.1](https://github.com/yumafuu/ghq-fzf/commits/v0.0.1) - 2024-12-12


### PR DESCRIPTION
This pull request is for the next release as v0.0.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->



**Full Changelog**: https://github.com/yumafuu/ghq-fzf/compare/v0.0.1...v0.0.2