### PR TITLE
Release for v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.0.2](https://github.com/yumafuu/ghq-fzf/compare/v0.0.1...v0.0.2) - 2025-04-21
+- [fix] goreleaser by @yumafuu in https://github.com/yumafuu/ghq-fzf/pull/38
+
 ## [v0.0.6](https://github.com/yumafuu/ghq-fzf/compare/v0.0.5...v0.0.6) - 2025-04-21
 - [update] ci by @yumafuu in https://github.com/yumafuu/ghq-fzf/pull/35
 - [update] ci by @yumafuu in https://github.com/yumafuu/ghq-fzf/pull/37


### PR DESCRIPTION
This pull request is for the next release as v0.0.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* [fix] goreleaser by @yumafuu in https://github.com/yumafuu/ghq-fzf/pull/38


**Full Changelog**: https://github.com/yumafuu/ghq-fzf/compare/v0.0.1...v0.0.2