### PR TITLE
Release for v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v1.0.1](https://github.com/yumafuu/ghq-fzf/compare/v1.0.0...v1.0.1) - 2025-04-21
+- [fix] binary by @yumafuu in https://github.com/yumafuu/ghq-fzf/pull/49
+
 ## [v0.0.5](https://github.com/yumafuu/ghq-fzf/compare/v0.0.4...v0.0.5) - 2025-04-21
 - [fix] ci by @yumafuu in https://github.com/yumafuu/ghq-fzf/pull/44
 - [update] readme by @yumafuu in https://github.com/yumafuu/ghq-fzf/pull/46


### PR DESCRIPTION
This pull request is for the next release as v1.0.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.0.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* [fix] binary by @yumafuu in https://github.com/yumafuu/ghq-fzf/pull/49


**Full Changelog**: https://github.com/yumafuu/ghq-fzf/compare/v1.0.0...v1.0.1